### PR TITLE
Add tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,11 @@
-name: Tests
+name: CI
 
 on:
   push:
   pull_request:
 
 jobs:
-  run_unit_tests:
+  r-checks:
     runs-on: ubuntu-latest
 
     steps:
@@ -22,26 +22,12 @@ jobs:
         with:
           extra-packages: |
             any::testthat
+            any::lintr
+            any::styler
 
       - name: Run R unit tests
         run: |
           Rscript -e 'testthat::test_dir("tests/testthat", reporter = "summary")'
-
-  run_style_tests:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Set up R
-        uses: r-lib/actions/setup-r@v2
-        with:
-          use-public-rspm: true
-
-      - name: Install and cache R dependencies
-        uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          extra-packages: |
-            any::lintr
-            any::styler
 
       - name: Check R formatting
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,9 @@
 name: CI
 
 on:
-  push:
   pull_request:
+  push:
+    branches: [main]
 
 jobs:
   r-checks:

--- a/README.md
+++ b/README.md
@@ -174,6 +174,15 @@ bash run_snakemake.sh \
 
 ## Development Notes
 
+### Testing
+
+Run tests locally with:
+
+```
+Rscript -e 'testthat::test_dir("tests/testthat")'
+
+```
+
 ### CI/CD
 
 TODO: add detail for this. CI/CD on GitHub will check styler and linter.

--- a/scripts/filt_mono.R
+++ b/scripts/filt_mono.R
@@ -1,50 +1,73 @@
 #!/usr/bin/env Rscript
 
+# Script is called by create_initial_input. Requires PLINK2 .afreq file and
+# path to log file. Removes monomorphic SNPs.
+
 library(argparse)
 
-parser <- ArgumentParser(
-  description = "Rscript filt_mono.R run by create_initial_input.sh.")
+filt_mono <- function(afreq_file, log_file) {
+  # Throw error if .afreq file is empty
+  if (file.size(afreq_file) == 0) {
+    stop("PLINK2 .afreq file is empty")
+  }
 
-parser$add_argument(
-  "-a", "--afreq", help="PLINK2 .afreq file path (required)", required=TRUE)
-parser$add_argument(
-  "-l", "--log", help="Create initial input log file (required)", required=TRUE)
+  afreq <- read.delim(afreq_file)
 
-args <- parser$parse_args()
+  # Throw error if ALT_FREQS column is missing
+  if (!"ALT_FREQS" %in% colnames(afreq)) {
+    stop("ALT_FREQS column is missing from .afreq file")
+  }
 
-# Monomorphic variants ---------------------------------------------------------
+  afreq_rm <- afreq[afreq$ALT_FREQS == 0, ]
+  afreq_rm_ct <- nrow(afreq_rm)
 
-#TODO: temp for testing!
-# afreq <- read.delim(
-#   "/Users/slacksa/temp_data/daisy/new_tm_imp_test/pre_qc/tmp_miss_mono.afreq")
-afreq <- read.delim(args$afreq)
+  log_entry <- data.frame(
+    Category = "Pre-Filtering",
+    Description = "Remove monomorphic SNPs",
+    Samples = "()",
+    SNPs = paste0("(", afreq_rm_ct, ")"),
+    stringsAsFactors = FALSE
+  )
 
-afreq_rm <- afreq[afreq$ALT_FREQS == 0, ]
-afreq_rm_ct <- nrow(afreq_rm)
+  path <- dirname(afreq_file)
+  write.table(
+    afreq_rm$ID,
+    file = paste0(path, "/tmp_mono_rm.txt"),
+    sep = "\t",
+    quote = FALSE,
+    row.names = FALSE,
+    col.names = FALSE
+  )
 
-log_entry <- data.frame(
-  Category = "Pre-Filtering",
-  Description = "Remove monomorphic SNPs",
-  Samples = "()",
-  SNPs = paste0("(", afreq_rm_ct, ")"),
-  stringsAsFactors = FALSE)
+  write.table(
+    log_entry,
+    file = log_file,
+    sep = "\t",
+    quote = FALSE,
+    row.names = FALSE,
+    col.names = FALSE,
+    append = TRUE
+  )
+}
 
-# Write out --------------------------------------------------------------------
+main <- function() {
+  parser <- ArgumentParser(
+    description = "Rscript filt_mono.R run by create_initial_input.sh."
+  )
 
-path <- dirname(args$afreq)
-write.table(
-  afreq_rm$ID,
-  file = paste0(path, "/tmp_mono_rm.txt"),
-  sep="\t",
-  quote=F,
-  row.names=F,
-  col.names=F)
+  parser$add_argument(
+    "-a", "--afreq",
+    help = "PLINK2 .afreq file path (required)", required = TRUE
+  )
+  parser$add_argument(
+    "-l", "--log",
+    help = "Create initial input log file (required)", required = TRUE
+  )
 
-write.table(
-  log_entry,
-  file = args$log,
-  sep = "\t",
-  quote = F,
-  row.names = F,
-  col.names = F,
-  append = T)
+  args <- parser$parse_args()
+  filt_mono(args$afreq, args$log)
+}
+
+if (sys.nframe() == 0) {
+  main()
+}

--- a/scripts/get_strand_amb_SNPs.R
+++ b/scripts/get_strand_amb_SNPs.R
@@ -8,6 +8,11 @@
 library(argparse)
 
 get_strand_amb_SNPs <- function(bim_file) { # nolint: object_name_linter
+  # Throw error if bim file is empty
+  if (file.size(bim_file) == 0) {
+    stop("BIM file is empty")
+  }
+
   bim <- read.table(bim_file, stringsAsFactors = FALSE)
   snps <- bim$V2[
     ((bim$V5 == "A") & (bim$V6 == "T")) |

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1,1 +1,2 @@
 source("../../scripts/get_strand_amb_SNPs.R")
+source("../../scripts/filt_mono.R")

--- a/tests/testthat/test_filt_mono.R
+++ b/tests/testthat/test_filt_mono.R
@@ -1,0 +1,135 @@
+library(testthat)
+
+make_afreq <- function(path, ids, alt_freqs) {
+  afreq <- data.frame(
+    `#CHROM` = rep(1, length(ids)),
+    ID = ids,
+    REF = "A",
+    ALT = "G",
+    `PROVISIONAL_REF?` = "Y",
+    ALT_FREQS = alt_freqs,
+    OBS_CT = 200
+  )
+  write.table(afreq, path, sep = "\t", quote = FALSE, row.names = FALSE)
+}
+
+test_that("filt_mono writes only monomorphic SNP IDs and logs their count", {
+  test_dir <- tempfile("filt_mono_")
+  dir.create(test_dir, recursive = TRUE)
+  on.exit(unlink(test_dir, recursive = TRUE))
+
+  afreq_file <- file.path(test_dir, "tmp_mono.afreq")
+  make_afreq(
+    afreq_file,
+    ids = c("snp1", "snp2", "snp3", "snp4"),
+    alt_freqs = c(0, 0.25, 0, 0.5)
+  )
+
+  log_file <- file.path(test_dir, "log.tsv")
+  file.create(log_file)
+
+  filt_mono(afreq_file, log_file)
+
+  actual_ids <- readLines(file.path(test_dir, "tmp_mono_rm.txt"))
+  expect_equal(actual_ids, c("snp1", "snp3"))
+
+  log_lines <- readLines(log_file)
+  expect_equal(
+    log_lines,
+    "Pre-Filtering\tRemove monomorphic SNPs\t()\t(2)"
+  )
+})
+
+test_that("filt_mono handles case of no monomorphic SNPs", {
+  test_dir <- tempfile("filt_mono_")
+  dir.create(test_dir, recursive = TRUE)
+  on.exit(unlink(test_dir, recursive = TRUE))
+
+  afreq_file <- file.path(test_dir, "tmp_mono.afreq")
+  make_afreq(
+    afreq_file,
+    ids = c("snp1", "snp2"),
+    alt_freqs = c(0.1, 0.5)
+  )
+
+  log_file <- file.path(test_dir, "log.tsv")
+  file.create(log_file)
+
+  filt_mono(afreq_file, log_file)
+
+  actual_ids <- readLines(file.path(test_dir, "tmp_mono_rm.txt"))
+  expect_equal(actual_ids, character(0))
+
+  log_lines <- readLines(log_file)
+  expect_equal(
+    log_lines,
+    "Pre-Filtering\tRemove monomorphic SNPs\t()\t(0)"
+  )
+})
+
+test_that("filt_mono appends its log entry after existing log content", {
+  test_dir <- tempfile("filt_mono_")
+  dir.create(test_dir, recursive = TRUE)
+  on.exit(unlink(test_dir, recursive = TRUE))
+
+  afreq_file <- file.path(test_dir, "tmp_mono.afreq")
+  make_afreq(afreq_file, ids = "snp1", alt_freqs = 0)
+
+  log_file <- file.path(test_dir, "log.tsv")
+  writeLines(
+    "Pre-Filtering\tRemove SNPs with missingness > 20%\t()\t(5)",
+    log_file
+  )
+
+  filt_mono(afreq_file, log_file)
+
+  log_lines <- readLines(log_file)
+  expect_equal(
+    log_lines,
+    c(
+      "Pre-Filtering\tRemove SNPs with missingness > 20%\t()\t(5)",
+      "Pre-Filtering\tRemove monomorphic SNPs\t()\t(1)"
+    )
+  )
+})
+
+test_that("filt_mono throws an error if the .afreq file is empty", {
+  test_dir <- tempfile("filt_mono_")
+  dir.create(test_dir, recursive = TRUE)
+  on.exit(unlink(test_dir, recursive = TRUE))
+
+  afreq_file <- file.path(test_dir, "tmp_mono.afreq")
+  file.create(afreq_file)
+
+  log_file <- file.path(test_dir, "log.tsv")
+  file.create(log_file)
+
+  expect_error(
+    filt_mono(afreq_file, log_file),
+    "PLINK2 .afreq file is empty"
+  )
+})
+
+test_that("filt_mono throws an error if the ALT_FREQS column is missing", {
+  test_dir <- tempfile("filt_mono_")
+  dir.create(test_dir, recursive = TRUE)
+  on.exit(unlink(test_dir, recursive = TRUE))
+
+  afreq_file <- file.path(test_dir, "tmp_mono.afreq")
+  afreq <- data.frame(
+    `#CHROM` = 1,
+    ID = "snp1",
+    REF = "A",
+    ALT = "G",
+    OBS_CT = 200
+  )
+  write.table(afreq, afreq_file, sep = "\t", quote = FALSE, row.names = FALSE)
+
+  log_file <- file.path(test_dir, "log.tsv")
+  file.create(log_file)
+
+  expect_error(
+    filt_mono(afreq_file, log_file),
+    "ALT_FREQS column is missing from .afreq file"
+  )
+})

--- a/tests/testthat/test_get_strand_amb_SNPs.R
+++ b/tests/testthat/test_get_strand_amb_SNPs.R
@@ -5,23 +5,69 @@ test_that("get_strand_amb_SNPs writes only strand ambiguous SNP IDs", {
   dir.create(test_dir, recursive = TRUE)
   on.exit(unlink(test_dir, recursive = TRUE))
 
-  bim_file <- file.path(test_dir, "input.bim")
+  # Make BIM file with strand ambiguous SNPs
+  bim_file <- file.path(test_dir, ".bim")
   bim <- data.frame(
-    V1 = rep(1, 6),
-    V2 = c("at_snp", "ta_snp", "cg_snp", "gc_snp", "ac_snp", "ga_snp"),
-    V3 = 0,
-    V4 = seq(100, 600, 100),
-    V5 = c("A", "T", "C", "G", "A", "G"),
-    V6 = c("T", "A", "G", "C", "C", "A")
+    chr = rep(1, 6),
+    id = c("at_snp", "ta_snp", "cg_snp", "gc_snp", "ac_snp", "ga_snp"),
+    cm = 0,
+    pos = seq(100, 600, 100),
+    a1 = c("A", "T", "C", "G", "A", "G"),
+    a2 = c("T", "A", "G", "C", "C", "A")
   )
-
-  write.table(bim, bim_file, sep = "\t", quote = FALSE,
-              row.names = FALSE, col.names = FALSE)
+  write.table(bim, bim_file,
+    sep = "\t", quote = FALSE,
+    row.names = FALSE, col.names = FALSE
+  )
 
   get_strand_amb_SNPs(bim_file)
 
   actual <- readLines(file.path(test_dir, "tmp_strand_remove_snps.txt"))
   expected <- c("at_snp", "ta_snp", "cg_snp", "gc_snp")
-
   expect_equal(actual, expected)
+})
+
+test_that(
+  "get_strand_amb_SNPs writes empty file when no strand ambiguous SNPs",
+  {
+    test_dir <- tempfile("no_strand_amb_")
+    dir.create(test_dir, recursive = TRUE)
+    on.exit(unlink(test_dir, recursive = TRUE))
+
+    # Make BIM file with no strand ambiguous SNPs
+    bim_file <- file.path(test_dir, ".bim")
+    bim <- data.frame(
+      chr = rep(1, 4),
+      id = c("ac_snp", "ga_snp", "ca_snp", "ag_snp"),
+      cm = 0,
+      pos = seq(100, 400, 100),
+      a1 = c("A", "G", "C", "A"),
+      a2 = c("C", "A", "A", "G")
+    )
+    write.table(bim, bim_file,
+      sep = "\t", quote = FALSE,
+      row.names = FALSE, col.names = FALSE
+    )
+
+    get_strand_amb_SNPs(bim_file)
+
+    actual <- readLines(file.path(test_dir, "tmp_strand_remove_snps.txt"))
+    expected <- character(0)
+    expect_equal(actual, expected)
+  }
+)
+
+test_that("get_strand_amb_SNPs throws an error when BIM file is empty", {
+  test_dir <- tempfile("empty_bim_")
+  dir.create(test_dir, recursive = TRUE)
+  on.exit(unlink(test_dir, recursive = TRUE))
+
+  # Make empty BIM file
+  bim_file <- file.path(test_dir, ".bim")
+  write.table(data.frame(), bim_file,
+    sep = "\t", quote = FALSE,
+    row.names = FALSE, col.names = FALSE
+  )
+
+  expect_error(get_strand_amb_SNPs(bim_file), "BIM file is empty")
 })


### PR DESCRIPTION
This branch includes re-factoring of R scripts to add unit tests for all to tests/testthat. Unit tests are run by GitHub CI on pull request or push to main. Also simplified CI workflow to only install R once.

Files updated:
- get_strand_amb_SNPs.R
- filt_mono.R
- test_get_strand_amb_SNPs.R
- ci.yml
- README.md

Files added:
- test_filt_mono.R